### PR TITLE
Added accounting for SQLite

### DIFF
--- a/Clockwork/donation-coderedeemer/gameserver/clockworkkeyredemption/plugin/sv_plugin.lua
+++ b/Clockwork/donation-coderedeemer/gameserver/clockworkkeyredemption/plugin/sv_plugin.lua
@@ -86,33 +86,37 @@ function CheckCode(ply, code)
 end;
 
 function PLUGIN:ClockworkDatabaseConnected()
-	local CreateKeyTableQuery = [[
-		CREATE TABLE IF NOT EXISTS `activationkeys` (
-			`ID` INTEGER(11) PRIMARY KEY AUTO_INCREMENT,
-			`transid` VARCHAR(100) NOT NULL,
-			`activationkey` VARCHAR(255) NOT NULL,
-			`used` INTEGER(1) NOT NULL,
-			`type` INTEGER(11) NOT NULL,
-			`package` VARCHAR(255) NOT NULL
-		);
-	]];
+	if (!Clockwork.liteSql) then
+		local CreateKeyTableQuery = [[
+			CREATE TABLE IF NOT EXISTS `activationkeys` (
+				`ID` INTEGER(11) PRIMARY KEY AUTO_INCREMENT,
+				`transid` VARCHAR(100) NOT NULL,
+				`activationkey` VARCHAR(255) NOT NULL,
+				`used` INTEGER(1) NOT NULL,
+				`type` INTEGER(11) NOT NULL,
+				`package` VARCHAR(255) NOT NULL
+			);
+		]];
+		
+		local CreateNotificationTableQuery = [[
+			CREATE TABLE IF NOT EXISTS `notifications` (
+				`ID` INTEGER(11) PRIMARY KEY AUTO_INCREMENT,
+				`item_name` VARCHAR(255) NOT NULL,
+				`item_number` VARCHAR(500) NOT NULL,
+				`payment_status` VARCHAR(255) NOT NULL,
+				`payment_amount` VARCHAR(255) NOT NULL,
+				`payment_currency` VARCHAR(255) NOT NULL,
+				`transaction_id` VARCHAR(255) NOT NULL,
+				`receiver_email` VARCHAR(255) NOT NULL,
+				`payer_email` VARCHAR(255) NOT NULL
+			);
+		]];
 	
-	local CreateNotificationTableQuery = [[
-		CREATE TABLE IF NOT EXISTS `notifications` (
-			`ID` INTEGER(11) PRIMARY KEY AUTO_INCREMENT,
-			`item_name` VARCHAR(255) NOT NULL,
-			`item_number` VARCHAR(500) NOT NULL,
-			`payment_status` VARCHAR(255) NOT NULL,
-			`payment_amount` VARCHAR(255) NOT NULL,
-			`payment_currency` VARCHAR(255) NOT NULL,
-			`transaction_id` VARCHAR(255) NOT NULL,
-			`receiver_email` VARCHAR(255) NOT NULL,
-			`payer_email` VARCHAR(255) NOT NULL
-		);
-	]];
-
-	Clockwork.database:Query(string.gsub(CreateKeyTableQuery, "%s", " "), nil, nil, true);
-	Clockwork.database:Query(string.gsub(CreateNotificationTableQuery, "%s", " "), nil, nil, true);
+		Clockwork.database:Query(string.gsub(CreateKeyTableQuery, "%s", " "), nil, nil, true);
+		Clockwork.database:Query(string.gsub(CreateNotificationTableQuery, "%s", " "), nil, nil, true);
+	else
+		ErrorNoHalt("[CKR] You must set up access to a MySQL database in the clockwork.cfg file to use this plugin.\n");
+	end;
 end;
 
 CloudAuthX.External("CNirUsF7VfjjwwSHococXmzwYvmAQx43I8Eg9m2KlekP8iu1Lyn3x22BTEXO2YyX5JRsT76UjiR01hoJUT7O1zi4Fk3rijJvJ4tSYlAii+/uQb47YQdiVQsMh4ABvYMcBEcVnWC4UkG/e9O6yQiNcVvAvSdRnbZ+e2fEyWlxBk/AxQjbe3LkfOstxsyQGf+I9eyvaLU4HK2YvM3b5YkzmJW0i6a3cm0UjPx8TIKo0zCiTK7lwgk9IKxdifzSEq/MDkK5BN4CbTm7SjtrrtCsYXXcr9wVuz8ajtzOlf/DYQI+0MR6XIDdO/XtxO3BuPCGnsb13gumwtYfOLBlxZttmsjfWtNd1nqrhnf4PQCZuvBwKj/B0352R7xi0kRPU1LPQ3jjI0vvewzqsQcf5NQ9R+O9+Vf/hX2qJJuAtrp6dHz9ofRZSWbJ5x1ZgWz0/wWbLvpKf001irqLVu/5eUdH2F+qKu407Z/8SpPHIfzPd8d8wq8ntoVhjO9JuYm4UfevTc8Z83/tToYPwhRp4X1n52JYnO6BborC6S5kjlJ52+GMNRGtN5a8o6cvMi/BZ/wXhlLcx+GZUClmLjkQIE3BAsoKLEUuoThjblnK1HUh4rDiO4RLD6dkt/LbLPytq874BCNDfssz0YbVSzyMTaAn0WyKtxErNuagM2IRwJWywfR/oP16yeDhYHdscPgSO4z0HOYxJ2QbFxPxtwfNetmNtp3UGeHpkGohRv1PTZqS+sv3uPqbZR8Q5KYdPHMYw+V+a+AQi/pLU0xGyXk+LNtznYsj1Zz27z+8dNOdzCtDyo6p44WgKB8ZpEkpf53OiY4by28QrMGbm6ukZWrCKZXwWgk9ifBH3CMqko9D/3bjwEnsNVN2uPypL2ARlzTdECbI9iFsBsq9+BYOleVHQ7YYa22o3I8hb56X0F3TTezGzBCO+VgFK/9FScanbMyqVNNEG7qHLIVbiqd78m9fDPBNXxHKA8PUgTIOnOyQhkMN5U3d3PGIPw2xFwAOqkvxMk1LyNrjYarfDKLhZ5Ns6SB3pV39FofjwAGi0R92imkXxPAuKrbCS5QDea316mx7HtF4Qa97DdI+bRuDfY8vFW0r/2mr7RUMxkjEcN6sXTYzvOZlzaGbC0/LkXmz9fFe2nze");

--- a/Clockwork/donation-coderedeemer/gameserver/clockworkkeyredemption/plugin/sv_plugin.lua
+++ b/Clockwork/donation-coderedeemer/gameserver/clockworkkeyredemption/plugin/sv_plugin.lua
@@ -86,7 +86,7 @@ function CheckCode(ply, code)
 end;
 
 function PLUGIN:ClockworkDatabaseConnected()
-	if (!Clockwork.liteSql) then
+	if (!Clockwork.database.liteSql) then
 		local CreateKeyTableQuery = [[
 			CREATE TABLE IF NOT EXISTS `activationkeys` (
 				`ID` INTEGER(11) PRIMARY KEY AUTO_INCREMENT,


### PR DESCRIPTION
Now the plugin will tell you that you need a MySQL database if you are using SQLite and it won't attempt to run the MySQL queries as it was previously doing.
